### PR TITLE
fix: map Zellij to ASCII renderer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,18 @@ function toolNameToState(toolName: string): EmoteState {
   }
 }
 
+function isZellij(): boolean {
+  return !!process.env.ZELLIJ;
+}
+
 function createRenderer(config: any): Renderer {
+  // getCapabilities() does not detect Zellij; it reports image support from
+  // the parent terminal, but Zellij does not reliably pass image protocols through.
+  if (isZellij()) {
+    log(`createRenderer: using AsciiRenderer (Zellij)`);
+    return new AsciiRenderer();
+  }
+
   const caps = getCapabilities();
   if (caps.images === "kitty") {
     log(`createRenderer: using KittyRenderer`);


### PR DESCRIPTION
This project is rad!

Noticed that in my setup that the emote wouldn't render in [zellij](https://zellij.dev/) due to how upstream `getCapabilities` was categorizing zellij based on whatever the parent terminal happened to be (wezterm for me).

Here's a screengrab of the issue:
<img width="894" height="569" alt="zellij_norender" src="https://github.com/user-attachments/assets/11357f60-edfb-4261-88be-161c20d362c2" />

zellij 0.44.1
wezterm 0-unstable-2026-03-31
pi 0.74.0
pi-emote d4e231b

Proposing an explicit remapping straight to ASCII before all the `getCapabilities` branches, to get the zellij experience to match something like `tmux` or `screen`.  Let me know if this is worthwhile!