### PR TITLE
fix: prefer iTerm2 renderer in WezTerm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,18 @@ function toolNameToState(toolName: string): EmoteState {
   }
 }
 
+function isWezTerm(): boolean {
+  return process.env.TERM_PROGRAM?.toLowerCase() === "wezterm" || !!process.env.WEZTERM_PANE;
+}
+
 function createRenderer(config: any): Renderer {
+  if (isWezTerm()) {
+    log(`createRenderer: using ITermRenderer (WezTerm)`);
+    return new ITermRenderer(config.size);
+  }
+
   const caps = getCapabilities();
+
   if (caps.images === "kitty") {
     log(`createRenderer: using KittyRenderer`);
     return new KittyRenderer(config.size);


### PR DESCRIPTION
One more kinda like #1

Wezterm gets reported by `pi-tui` as `kitty` image capable, but I'm having much better success with the `iterm2` renderer.

Example screenshot showing the avatar missing top 1/3rd of image:
<img width="894" height="569" alt="wezterm_clipped" src="https://github.com/user-attachments/assets/a06fd8b7-a84e-4fd6-8a33-f02f54fc64d5" />

I don't have a gif handy, but it will also flicker the avatar upon submit of a prompt in the pi tui, disappearing for a noticeable second and then reappearing.

Smooth as butter once the renderer is updated to `iterm2`.

# References
https://github.com/wezterm/wezterm/issues/986
https://github.com/wezterm/wezterm/issues/5892