### PR TITLE
feat: add herdr support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ pi-emote uses layered configuration with deep merge. Higher-priority layers over
     { "match": "zellij", "render": "ascii" },
     { "match": "tmux", "render": "auto" },
     { "match": "screen", "render": "ascii" },
+    { "match": "herdr", "render": "kitty-unicode" },
     { "match": "wezterm", "render": "iterm2" },
     { "match": "ghostty", "render": "kitty" }
   ]
@@ -135,13 +136,14 @@ The `terminals` array maps detected terminal/multiplexer names to specific image
     { "match": "zellij", "render": "ascii" },
     { "match": "tmux", "render": "auto" },
     { "match": "screen", "render": "ascii" },
+    { "match": "herdr", "render": "kitty-unicode" },
     { "match": "wezterm", "render": "iterm2" },
     { "match": "ghostty", "render": "kitty" }
   ]
 }
 ```
 
-tmux defaults to `"auto"` — auto-detects the outer terminal. Ghostty and kitty get `kitty-unicode` (pane-safe image rendering); other outer terminals fall back to ASCII with a helpful message. Other multiplexers (zellij, screen) default to `"ascii"`. WezTerm uses iTerm2 protocol (more reliable than Kitty on WezTerm). Terminals not listed (e.g., kitty, iterm2) fall through to pi-tui auto-detection.
+tmux defaults to `"auto"` — auto-detects the outer terminal. Ghostty and kitty get `kitty-unicode` (pane-safe image rendering); other outer terminals fall back to ASCII with a helpful message. Other multiplexers (zellij, screen) default to `"ascii"`. WezTerm uses iTerm2 protocol (more reliable than Kitty on WezTerm). herdr is detected via `HERDR_PANE_ID` before the terminal-emulator checks, because it passes the outer terminal's `TERM_PROGRAM`/`GHOSTTY_RESOURCES_DIR` into panes; it gets `kitty-unicode` since it composes panes from a cell grid and discards cursor-anchored direct placements on repaint. Terminals not listed (e.g., kitty, iterm2) fall through to pi-tui auto-detection.
 
 ### tmux Requirements
 
@@ -165,7 +167,7 @@ The auto-detection flow for tmux (when render is `"auto"`):
 1. Check `allow-passthrough` is `on` or `all` via `tmux show-options -g`
 2. Detect outer terminal via `tmux show-environment TERM_PROGRAM` (session-level, falls back to global)
 3. Map outer terminal to protocol: ghostty/kitty → kitty-unicode (pane-safe), iTerm.app/WezTerm → ascii (no pane-safe renderer available)
-4. Use `TmuxKittyUnicodeRenderer` for Ghostty/kitty; all others fall back to ASCII
+4. Use `KittyUnicodeRenderer` (with tmux DCS passthrough enabled) for Ghostty/kitty; all others fall back to ASCII
 
 If the user explicitly configures a concrete render value (`"kitty"`, `"kitty-unicode"`, `"iterm2"`, `"ascii"`) for tmux, all auto-detection and warnings are skipped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to pi-emote will be documented in this file.
 
+## Unreleased
+
+### Added
+- **herdr support** — herdr panes are detected via `HERDR_PANE_ID` and render with the kitty-unicode renderer. Previously herdr was misidentified as its outer terminal (it passes `TERM_PROGRAM`/`GHOSTTY_RESOURCES_DIR` through to panes), so pi-emote emitted a direct placement that herdr's cell-grid compositor discards on repaint, leaving an empty box. Requires `experimental.kitty_graphics = true` in herdr's config, which only applies to panes created after it is enabled.
+
+### Changed
+- **`TmuxKittyUnicodeRenderer` is now `KittyUnicodeRenderer`** (`src/render_tmux_kitty_unicode.ts` → `src/render_kitty_unicode.ts`). The Unicode placeholder approach was never tmux-specific; only the DCS passthrough wrapping is, and that is now a constructor flag set for tmux alone. This makes `"render": "kitty-unicode"` usable outside tmux.
+- **`detectTerminalName()` moved to `src/detect_terminal.ts`**, unchanged apart from the herdr branch. It reads only environment variables, so keeping it free of the `@earendil-works/pi-tui` import lets it be unit tested without installing peer dependencies.
+
 ## v0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ iTerm2 and WezTerm use DCS passthrough for the iTerm2 image protocol. This works
 }
 ```
 
+### herdr
+
+[herdr](https://github.com/herdrdev/herdr) works with no setup, as long as herdr
+itself is told to render images:
+
+```toml
+# ~/.config/herdr/config.toml
+[experimental]
+kitty_graphics = true
+```
+
+The flag only applies to panes created after it is set, so open a new pane
+after enabling it.
+
+herdr passes the outer terminal's `TERM_PROGRAM` and `GHOSTTY_RESOURCES_DIR`
+into every pane, so pi-emote used to identify it as its host terminal and emit
+a cursor-anchored direct placement. herdr composes panes from a parsed cell
+grid, so those placements are wiped on the next repaint and the avatar shows as
+an empty box. pi-emote now detects herdr via `HERDR_PANE_ID` and uses the
+kitty-unicode renderer, whose Unicode placeholders live in the cell grid and
+survive repaints.
+
 ### Other Multiplexers
 
 **zellij** and **screen** are not yet supported and default to ASCII.

--- a/config.json
+++ b/config.json
@@ -20,6 +20,7 @@
     { "match": "zellij", "render": "ascii" },
     { "match": "tmux", "render": "auto" },
     { "match": "screen", "render": "ascii" },
+    { "match": "herdr", "render": "kitty-unicode" },
     { "match": "wezterm", "render": "iterm2" },
     { "match": "ghostty", "render": "kitty" },
     { "match": "warpterminal", "render": "kitty" }

--- a/src/detect_terminal.ts
+++ b/src/detect_terminal.ts
@@ -1,0 +1,38 @@
+/**
+ * Terminal identification from environment variables only.
+ *
+ * Kept free of runtime dependencies so it can be unit tested directly.
+ */
+
+/**
+ * Detect the terminal or multiplexer name from environment variables.
+ * Multiplexers are checked first — they set vars that leak through from
+ * the outer terminal emulator.
+ */
+export function detectTerminalName(): string {
+  const termProgram = (process.env.TERM_PROGRAM ?? "").toLowerCase();
+  const term = (process.env.TERM ?? "").toLowerCase();
+
+  // --- Multiplexers (checked first) ---
+  if (process.env.ZELLIJ_SESSION_NAME || process.env.ZELLIJ) return "zellij";
+  if (process.env.TMUX || term.startsWith("tmux")) return "tmux";
+  if (term.startsWith("screen")) return "screen";
+
+  // herdr runs panes under its own compositor but passes the outer terminal's
+  // TERM_PROGRAM/GHOSTTY_RESOURCES_DIR straight through, so it has to be
+  // checked before the emulator branches below or it is misread as its host.
+  // It is not in MULTIPLEXERS because it needs no tmux-style DCS passthrough.
+  if (process.env.HERDR_PANE_ID) return "herdr";
+
+  // --- Terminal emulators ---
+  if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") return "kitty";
+  if (process.env.GHOSTTY_RESOURCES_DIR || termProgram === "ghostty" || term.includes("ghostty")) return "ghostty";
+  if (process.env.WEZTERM_PANE || termProgram === "wezterm") return "wezterm";
+  if (process.env.ITERM_SESSION_ID || termProgram === "iterm.app") return "iterm2";
+  if (termProgram === "vscode") return "vscode";
+  if (termProgram === "alacritty") return "alacritty";
+  if (termProgram === "warpterminal") return "warpterminal";
+
+  return "unknown";
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { loadLayeredConfig } from "./config.js";
 import { resolveEmoteSet, findEmoteSetDir, loadEmotesConfig } from "./emotes.js";
 import { KittyRenderer } from "./render_kitty.js";
 import { TmuxKittyRenderer } from "./render_tmux_kitty.js";
-import { TmuxKittyUnicodeRenderer } from "./render_tmux_kitty_unicode.js";
+import { KittyUnicodeRenderer } from "./render_kitty_unicode.js";
 import { ITermRenderer } from "./render_iterm.js";
 import { TmuxITermRenderer } from "./render_tmux_iterm.js";
 import { AsciiRenderer } from "./render_ascii.js";
@@ -44,8 +44,10 @@ function toolNameToState(toolName: string): EmoteState {
 function createRendererFromResolved(resolved: ResolvedRenderer, size: number): Renderer {
   const { protocol, multiplexer } = resolved;
   if (protocol === "kitty-unicode") {
-    log(`createRenderer: using TmuxKittyUnicodeRenderer`);
-    return new TmuxKittyUnicodeRenderer(size);
+    // Only tmux needs the transmit wrapped in DCS passthrough.
+    const passthrough = multiplexer === "tmux";
+    log(`createRenderer: using KittyUnicodeRenderer (passthrough=${passthrough})`);
+    return new KittyUnicodeRenderer(size, passthrough);
   }
   if (protocol === "kitty") {
     if (multiplexer === "tmux") {

--- a/src/render_kitty_unicode.ts
+++ b/src/render_kitty_unicode.ts
@@ -51,9 +51,16 @@ function weightedRandomPick(weights: Record<string, number>): string {
 
 /**
  * Build the kitty graphics transmit sequence (with virtual placement U=1).
- * Handles chunking for large payloads. Wrapped in tmux passthrough.
+ * Handles chunking for large payloads. Wrapped in tmux passthrough only when
+ * we are actually inside tmux; other hosts want the bare sequence.
  */
-function buildTransmitSequence(base64: string, imageId: number, cols: number, rows: number): string {
+function buildTransmitSequence(
+  base64: string,
+  imageId: number,
+  cols: number,
+  rows: number,
+  passthrough: boolean,
+): string {
   const chunks: string[] = [];
   let offset = 0;
 
@@ -76,7 +83,8 @@ function buildTransmitSequence(base64: string, imageId: number, cols: number, ro
     chunks.push(`\x1b_Ga=T,f=100,q=2,U=1,i=${imageId},c=${cols},r=${rows},m=0;\x1b\\`);
   }
 
-  return wrapTmuxPassthrough(chunks.join(""));
+  const sequence = chunks.join("");
+  return passthrough ? wrapTmuxPassthrough(sequence) : sequence;
 }
 
 /**
@@ -102,25 +110,33 @@ function buildPlaceholderLines(imageId: number, cols: number, rows: number): str
 }
 
 /**
- * Kitty Unicode Placeholder renderer for tmux.
+ * Kitty Unicode Placeholder renderer.
  *
  * Uses kitty's virtual placement + Unicode placeholder approach:
- * 1. Transmit image data via DCS passthrough (creates virtual placement)
+ * 1. Transmit image data (creates virtual placement)
  * 2. Display via U+10EEEE placeholder characters (regular text)
  *
- * This makes the image behave like normal text — tmux constrains it to
- * the pane, and switching sessions clears it naturally.
+ * This makes the image behave like normal text, so any host that composes a
+ * cell grid keeps the image anchored to its cells instead of to a cursor
+ * position. tmux constrains it to the pane and clears it on session switch;
+ * terminal multiplexers that repaint panes (herdr) keep it across redraws
+ * that would wipe a cursor-anchored direct placement.
+ *
+ * Pass `passthrough: true` only inside tmux, which needs the transmit wrapped
+ * in a DCS escape. Everywhere else the bare sequence is correct.
  */
-export class TmuxKittyUnicodeRenderer implements Renderer {
+export class KittyUnicodeRenderer implements Renderer {
   private tuiRef: TUI | null = null;
   private frameMap: Map<EmoteState, FrameSet> = new Map();
   private lastShownBase64: string | null = null;
   private currentFrame: RenderedFrame | null = null;
   private size: number;
   private imageId: number;
+  private passthrough: boolean;
 
-  constructor(size: number) {
+  constructor(size: number, passthrough = false) {
     this.size = size;
+    this.passthrough = passthrough;
     // Random 24-bit image ID (required for truecolor encoding)
     this.imageId = Math.floor(Math.random() * 0xFFFFFE) + 1;
   }
@@ -146,14 +162,14 @@ export class TmuxKittyUnicodeRenderer implements Renderer {
     const cols = this.size;
     const rows = calculateImageRows(dims, cols, cellDims);
 
-    // Transmit image data via passthrough (uploads to terminal's image store)
-    const transmit = buildTransmitSequence(base64, this.imageId, cols, rows);
+    // Transmit image data (uploads to terminal's image store)
+    const transmit = buildTransmitSequence(base64, this.imageId, cols, rows, this.passthrough);
     process.stdout.write(transmit);
 
     // Build placeholder grid as text lines
     const lines = buildPlaceholderLines(this.imageId, cols, rows);
 
-    log(`TmuxKittyUnicodeRenderer.show: dims=${dims.widthPx}x${dims.heightPx}, cols=${cols}, rows=${rows}, imageId=${this.imageId}`);
+    log(`KittyUnicodeRenderer.show: dims=${dims.widthPx}x${dims.heightPx}, cols=${cols}, rows=${rows}, imageId=${this.imageId}, passthrough=${this.passthrough}`);
 
     this.currentFrame = { kind: "placeholder", lines, rows };
     this.tuiRef?.requestRender();
@@ -218,7 +234,7 @@ export class TmuxKittyUnicodeRenderer implements Renderer {
   dispose() {
     // Delete image from terminal's graphics memory
     const del = `\x1b_Ga=d,d=I,i=${this.imageId},q=2\x1b\\`;
-    process.stdout.write(wrapTmuxPassthrough(del));
+    process.stdout.write(this.passthrough ? wrapTmuxPassthrough(del) : del);
     this.currentFrame = null;
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,37 +1,14 @@
 import { getCapabilities } from "@earendil-works/pi-tui";
 import type { TerminalMapping, ResolvedRenderer } from "./types.js";
 import { checkTmuxPassthrough, detectOuterTerminal } from "./tmux.js";
+import { detectTerminalName } from "./detect_terminal.js";
 import { log } from "./log.js";
+
+export { detectTerminalName };
 
 type Protocol = "kitty" | "kitty-unicode" | "iterm2" | "ascii";
 
 const MULTIPLEXERS = new Set(["tmux", "screen", "zellij"]);
-
-/**
- * Detect the terminal or multiplexer name from environment variables.
- * Multiplexers are checked first — they set vars that leak through from
- * the outer terminal emulator.
- */
-export function detectTerminalName(): string {
-  const termProgram = (process.env.TERM_PROGRAM ?? "").toLowerCase();
-  const term = (process.env.TERM ?? "").toLowerCase();
-
-  // --- Multiplexers (checked first) ---
-  if (process.env.ZELLIJ_SESSION_NAME || process.env.ZELLIJ) return "zellij";
-  if (process.env.TMUX || term.startsWith("tmux")) return "tmux";
-  if (term.startsWith("screen")) return "screen";
-
-  // --- Terminal emulators ---
-  if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") return "kitty";
-  if (process.env.GHOSTTY_RESOURCES_DIR || termProgram === "ghostty" || term.includes("ghostty")) return "ghostty";
-  if (process.env.WEZTERM_PANE || termProgram === "wezterm") return "wezterm";
-  if (process.env.ITERM_SESSION_ID || termProgram === "iterm.app") return "iterm2";
-  if (termProgram === "vscode") return "vscode";
-  if (termProgram === "alacritty") return "alacritty";
-  if (termProgram === "warpterminal") return "warpterminal";
-
-  return "unknown";
-}
 
 /**
  * Resolve which renderer to use.

--- a/tests/terminal-detect.test.ts
+++ b/tests/terminal-detect.test.ts
@@ -1,0 +1,60 @@
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { detectTerminalName } from "../src/detect_terminal.ts";
+
+const TOUCHED = [
+  "HERDR_PANE_ID",
+  "TMUX",
+  "TERM",
+  "TERM_PROGRAM",
+  "GHOSTTY_RESOURCES_DIR",
+  "KITTY_WINDOW_ID",
+  "ZELLIJ",
+  "ZELLIJ_SESSION_NAME",
+];
+
+const saved = new Map(TOUCHED.map((k) => [k, process.env[k]]));
+
+afterEach(() => {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+function only(env: Record<string, string>) {
+  for (const k of TOUCHED) delete process.env[k];
+  Object.assign(process.env, env);
+}
+
+test("herdr is detected even though it inherits the outer terminal's env", () => {
+  // A herdr pane launched from Ghostty sees both of these, which is exactly
+  // the case that used to resolve to "ghostty" and pick direct placement.
+  only({
+    HERDR_PANE_ID: "w1:p1",
+    TERM: "xterm-256color",
+    TERM_PROGRAM: "ghostty",
+    GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app/Contents/Resources/ghostty",
+  });
+  assert.equal(detectTerminalName(), "herdr");
+});
+
+test("herdr wins over a leaked kitty identity too", () => {
+  only({ HERDR_PANE_ID: "w2:p1", TERM: "xterm-kitty", KITTY_WINDOW_ID: "3" });
+  assert.equal(detectTerminalName(), "herdr");
+});
+
+test("tmux inside herdr still resolves to tmux, so DCS passthrough is kept", () => {
+  only({ HERDR_PANE_ID: "w1:p1", TMUX: "/tmp/tmux-501/default,123,0", TERM: "tmux-256color" });
+  assert.equal(detectTerminalName(), "tmux");
+});
+
+test("plain ghostty is unaffected", () => {
+  only({ TERM: "xterm-256color", TERM_PROGRAM: "ghostty" });
+  assert.equal(detectTerminalName(), "ghostty");
+});
+
+test("unknown terminal stays unknown", () => {
+  only({ TERM: "xterm-256color" });
+  assert.equal(detectTerminalName(), "unknown");
+});


### PR DESCRIPTION
herdr passes the outer terminal's `TERM_PROGRAM` and `GHOSTTY_RESOURCES_DIR` into every pane, so pi-emote identified it as Ghostty and emitted a cursor-anchored direct placement. herdr composes panes from a parsed cell grid and drops those placements on the next repaint, so the avatar shows up as an empty box.

This detects herdr via `HERDR_PANE_ID` and routes it to the Unicode placeholder renderer, whose cells live in the grid and survive repaints. That renderer was only reachable from tmux, so the DCS passthrough wrapping is now a constructor flag and the class is `KittyUnicodeRenderer`; tmux behaviour is unchanged. `detectTerminalName` moved to a dependency-free module so it can be unit tested without installing peer deps.

Requires `experimental.kitty_graphics = true` on herdr's side, which only applies to panes created after it's set.

Tested on herdr 0.8.0 under Ghostty on macOS.
