### PR TITLE
Add a session-only widget visibility command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to pi-emote will be documented in this file.
 
+## Unreleased
+
+### Added
+- **Widget visibility command** — `/pi-emote-toggle` hides or restores the widget for the current session without changing the persistent `enabled` setting.
+
 ## v0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ pi install git:github.com/cgxeiji/pi-emote
 | failure | Failed tool execution |
 | compact | Context compaction |
 
+## Command
+
+Use `/pi-emote-toggle` to hide or restore the widget for the current session. This does not change the persistent `enabled` setting.
+
 ## Config
 
 Drop a `config.json` in one of these paths (highest priority wins):

--- a/src/animator.ts
+++ b/src/animator.ts
@@ -1,7 +1,6 @@
 import type { TUI } from "@earendil-works/pi-tui";
 import type { EmoteState, Config, EmotesConfig } from "./types.js";
 import type { Renderer, RenderedFrame } from "./renderer.js";
-import { log } from "./log.js";
 
 // --- Helpers ---
 
@@ -28,6 +27,7 @@ export class Animator {
   private thinkTimer: ReturnType<typeof setTimeout> | null = null;
   private talkGapTimer: ReturnType<typeof setTimeout> | null = null;
   private talkDurationTimer: ReturnType<typeof setTimeout> | null = null;
+  private frameTimers = new Set<ReturnType<typeof setTimeout>>();
 
   // Cycle state
   private cycleIndex = 0;
@@ -82,6 +82,19 @@ export class Animator {
 
   // --- Timer management ---
 
+  private scheduleFrameTimer(callback: () => void, delay: number) {
+    const timer = setTimeout(() => {
+      this.frameTimers.delete(timer);
+      callback();
+    }, delay);
+    this.frameTimers.add(timer);
+  }
+
+  private clearFrameTimers() {
+    for (const timer of this.frameTimers) clearTimeout(timer);
+    this.frameTimers.clear();
+  }
+
   clearAllTimers() {
     if (this.holdTimer) { clearTimeout(this.holdTimer); this.holdTimer = null; }
     if (this.blinkTimer) { clearTimeout(this.blinkTimer); this.blinkTimer = null; }
@@ -90,6 +103,7 @@ export class Animator {
     if (this.talkGapTimer) { clearTimeout(this.talkGapTimer); this.talkGapTimer = null; }
     if (this.talkDurationTimer) { clearTimeout(this.talkDurationTimer); this.talkDurationTimer = null; }
     if (this.thinkTimer) { clearTimeout(this.thinkTimer); this.thinkTimer = null; }
+    this.clearFrameTimers();
   }
 
   private clearStateTimers() {
@@ -99,6 +113,7 @@ export class Animator {
     if (this.talkGapTimer) { clearTimeout(this.talkGapTimer); this.talkGapTimer = null; }
     if (this.talkDurationTimer) { clearTimeout(this.talkDurationTimer); this.talkDurationTimer = null; }
     if (this.thinkTimer) { clearTimeout(this.thinkTimer); this.thinkTimer = null; }
+    this.clearFrameTimers();
   }
 
   // --- State transitions ---
@@ -156,15 +171,15 @@ export class Animator {
     const blinkDuration = 150;
     const defaultFile = this.emotesConfig.idle?.default ?? "idle.png";
 
-    setTimeout(() => {
+    this.scheduleFrameTimer(() => {
       if (this.currentState !== "idle") return;
       this.renderer.showFrame("idle", defaultFile, true);
 
       if (doubleBlink) {
-        setTimeout(() => {
+        this.scheduleFrameTimer(() => {
           if (this.currentState !== "idle") return;
           this.renderer.showFrame("idle", blinkFile, true);
-          setTimeout(() => {
+          this.scheduleFrameTimer(() => {
             if (this.currentState !== "idle") return;
             this.renderer.showFrame("idle", defaultFile, true);
             this.scheduleBlink();
@@ -199,7 +214,7 @@ export class Animator {
     }
 
     const defaultFile = this.emotesConfig.think?.default ?? "think.png";
-    setTimeout(() => {
+    this.scheduleFrameTimer(() => {
       if (this.currentState !== "think") return;
       this.renderer.showFrame("think", defaultFile, true);
       this.scheduleThinkSwap();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { AsciiRenderer } from "./render_ascii.js";
 import { Animator } from "./animator.js";
 import { createWidgetFactory } from "./widget.js";
 import { resolveRenderer } from "./terminal.js";
+import { createWidgetVisibility, registerVisibilityCommand } from "./visibility.js";
 
 const IMAGE_STATES = ["hi", "idle", "think", "talk", "read", "write", "tool", "success", "failure", "compact"];
 
@@ -80,7 +81,7 @@ export default function (pi: ExtensionAPI) {
   // Emote set state
   let currentEmoteSet = "default";
   let ctxRef: any = null;
-  let widgetActive = false;
+  let introTimer: ReturnType<typeof setTimeout> | null = null;
   let lastResolved = resolveRenderer(config.terminals, userConfiguredTerminals);
   let renderer = createRendererFromResolved(lastResolved, config.size);
 
@@ -120,13 +121,46 @@ export default function (pi: ExtensionAPI) {
       loadEmoteSet(setName);
       log(`switchEmoteSet: loaded "${setName}", state="${animator.currentState}"`);
       animator.resetRenderCache();
-      if (widgetActive && animator.currentState === "idle") {
+      if (visibility.isVisible() && animator.currentState === "idle") {
         animator.enterIdle();
-      } else if (widgetActive) {
+      } else if (visibility.isVisible()) {
         renderer.showRandomFrame(animator.currentState, true);
       }
     }
   }
+
+  function clearIntroTimer() {
+    if (!introTimer) return;
+    clearTimeout(introTimer);
+    introTimer = null;
+  }
+
+  const visibility = createWidgetVisibility({
+    show: () => {
+      const modelId = ctxRef?.model?.id ?? "";
+      switchEmoteSet(modelId, pi.getThinkingLevel());
+
+      ctxRef.ui.setWidget("emote", createWidgetFactory({
+        animator,
+        config,
+        pi,
+        getCtxRef: () => ctxRef,
+        getCurrentEmoteSet: () => currentEmoteSet,
+      }), { placement: "aboveEditor" });
+
+      animator.resetRenderCache();
+      animator.transitionTo("idle");
+    },
+    hide: () => {
+      clearIntroTimer();
+      animator.clearAllTimers();
+      animator.disposeRenderer();
+      ctxRef.ui.setWidget("emote", undefined);
+      animator.setTui(null);
+    },
+  });
+
+  registerVisibilityCommand(pi, visibility);
 
   // --- Events ---
 
@@ -162,32 +196,21 @@ export default function (pi: ExtensionAPI) {
     log(`session_start: model="${modelId}" thinkingLevel="${thinkingLevel}" set="${setName}" dir="${findEmoteSetDir(setName, extDir, cwd)}"`);
     loadEmoteSet(setName);
 
-    // Create widget
-    ctx.ui.setWidget("emote", createWidgetFactory({
-      animator,
-      config,
-      pi,
-      getCtxRef: () => ctxRef,
-      getCurrentEmoteSet: () => currentEmoteSet,
-    }), { placement: "aboveEditor" });
-
-    widgetActive = true;
-    setTimeout(() => animator.transitionTo("hi"), 500);
+    visibility.show();
+    introTimer = setTimeout(() => {
+      introTimer = null;
+      if (visibility.isVisible()) animator.transitionTo("hi");
+    }, 500);
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    animator.clearAllTimers();
-    animator.disposeRenderer();
-    if (widgetActive && ctx.hasUI) {
-      ctx.ui.setWidget("emote", undefined);
-      widgetActive = false;
-    }
-    animator.setTui(null);
+    clearIntroTimer();
+    if (visibility.isVisible() && ctx.hasUI) visibility.hide();
     ctxRef = null;
   });
 
   pi.on("model_select", async (event) => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     const modelId = event.model?.id ?? "";
     const thinkingLevel = pi.getThinkingLevel();
     const resolved = resolveEmoteSet(modelId, thinkingLevel, config.emotes);
@@ -196,7 +219,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("thinking_level_select", async (event, ctx) => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     const modelId = ctx.model?.id ?? "";
     const resolved = resolveEmoteSet(modelId, event.level, config.emotes);
     log(`thinking_level_select: model="${modelId}" thinkingLevel="${event.level}" resolved="${resolved}" current="${currentEmoteSet}"`);
@@ -204,7 +227,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("message_update", async (event) => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     if (event.message?.role !== "assistant") return;
 
     const streamEvent = event.assistantMessageEvent;
@@ -239,7 +262,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_end", async () => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     if (animator.currentState === "talk") {
       animator.endTalk();
     } else if (animator.currentState !== "idle" && animator.currentState !== "hi" && animator.currentState !== "compact") {
@@ -248,12 +271,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("tool_execution_start", async (event) => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     animator.transitionTo(toolNameToState(event.toolName));
   });
 
   pi.on("tool_execution_end", async (event) => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     if (event.toolName === "bash" && event.isError) {
       animator.setHoldNextState("read");
       animator.transitionTo("failure");
@@ -263,12 +286,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_before_compact", async () => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     animator.transitionTo("compact");
   });
 
   pi.on("session_compact", async () => {
-    if (!widgetActive) return;
+    if (!visibility.isVisible()) return;
     animator.transitionTo("idle");
   });
 }

--- a/src/visibility.ts
+++ b/src/visibility.ts
@@ -1,0 +1,50 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+interface VisibilityActions {
+  show(): void;
+  hide(): void;
+}
+
+export interface WidgetVisibility {
+  isVisible(): boolean;
+  show(): boolean;
+  hide(): boolean;
+  toggle(): boolean;
+}
+
+export function createWidgetVisibility(actions: VisibilityActions): WidgetVisibility {
+  let visible = false;
+
+  const show = () => {
+    if (visible) return true;
+    actions.show();
+    visible = true;
+    return visible;
+  };
+
+  const hide = () => {
+    if (!visible) return false;
+    actions.hide();
+    visible = false;
+    return visible;
+  };
+
+  return {
+    isVisible: () => visible,
+    show,
+    hide,
+    toggle: () => visible ? hide() : show(),
+  };
+}
+
+export function registerVisibilityCommand(pi: ExtensionAPI, visibility: WidgetVisibility) {
+  pi.registerCommand("pi-emote-toggle", {
+    description: "Show or hide the pi-emote widget",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) return;
+
+      const visible = visibility.toggle();
+      ctx.ui.notify(`[pi-emote] Widget ${visible ? "shown" : "hidden"}.`, "info");
+    },
+  });
+}

--- a/tests/animator-cleanup.test.ts
+++ b/tests/animator-cleanup.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Animator } from "../src/animator.ts";
+import type { Config, EmoteState, EmotesConfig } from "../src/types.ts";
+import type { RenderedFrame, Renderer } from "../src/renderer.ts";
+
+const config: Config = {
+  enabled: true,
+  debug: false,
+  size: 8,
+  readingSpeed: 4,
+  hideBelow: 40,
+  holdDuration: { hi: 2000, success: 1200, failure: 1200 },
+  blinkInterval: [0, 0],
+  talkTickMs: 120,
+  cycleMs: 500,
+  emotes: [],
+  terminals: [],
+  theme: {},
+};
+
+function createRendererSpy() {
+  const calls: string[] = [];
+  const renderer: Renderer = {
+    setTui() {},
+    loadFrames() {},
+    getRenderedFrame(): RenderedFrame | null { return null; },
+    showFrame(state: EmoteState, name: string) {
+      calls.push(`${state}:${name}`);
+      return true;
+    },
+    showRandomFrame(state: EmoteState) {
+      calls.push(`${state}:random`);
+      return true;
+    },
+    showTalkFrame(_emotesConfig: EmotesConfig) { return true; },
+    showTalkCloseFrame() { return true; },
+    showCycleFrame() { return true; },
+    getCycleFrameCount() { return 0; },
+    dispose() { calls.push("dispose"); },
+    resetCache() {},
+  };
+
+  return { calls, renderer };
+}
+
+test("hiding during a blink cancels delayed frame changes", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.mock.method(Math, "random", () => 0.5);
+  const { calls, renderer } = createRendererSpy();
+  const animator = new Animator(config, renderer);
+
+  animator.enterIdle();
+  t.mock.timers.tick(0);
+  assert.deepEqual(calls, ["idle:idle.png", "idle:idle_blink.png"]);
+
+  animator.clearAllTimers();
+  renderer.dispose();
+  t.mock.timers.tick(1000);
+
+  assert.deepEqual(calls, ["idle:idle.png", "idle:idle_blink.png", "dispose"]);
+});
+
+test("hiding during a think swap cancels its delayed frame change", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.mock.method(Math, "random", () => 0.5);
+  const { calls, renderer } = createRendererSpy();
+  const animator = new Animator(config, renderer);
+
+  animator.transitionTo("think");
+  t.mock.timers.tick(0);
+  assert.deepEqual(calls, ["think:think.png", "think:think_hard.png"]);
+
+  animator.clearAllTimers();
+  renderer.dispose();
+  t.mock.timers.tick(1000);
+
+  assert.deepEqual(calls, ["think:think.png", "think:think_hard.png", "dispose"]);
+});

--- a/tests/visibility.test.ts
+++ b/tests/visibility.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import { createWidgetVisibility, registerVisibilityCommand } from "../src/visibility.ts";
+
+test("pi-emote-toggle hides and restores the widget for the current session", async () => {
+  const transitions: string[] = [];
+  const notices: string[] = [];
+  const visibility = createWidgetVisibility({
+    show: () => transitions.push("show"),
+    hide: () => transitions.push("hide"),
+  });
+
+  let commandName = "";
+  let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+  registerVisibilityCommand({
+    registerCommand(name: string, options: { handler: typeof handler }) {
+      commandName = name;
+      handler = options.handler;
+    },
+  } as unknown as ExtensionAPI, visibility);
+
+  visibility.show();
+  assert.equal(visibility.isVisible(), true);
+  assert.deepEqual(transitions, ["show"]);
+  assert.equal(commandName, "pi-emote-toggle");
+
+  const ctx = {
+    hasUI: true,
+    ui: {
+      notify(message: string) {
+        notices.push(message);
+      },
+    },
+  };
+
+  await handler!("", ctx);
+  assert.equal(visibility.isVisible(), false);
+  assert.deepEqual(transitions, ["show", "hide"]);
+  assert.equal(notices.at(-1), "[pi-emote] Widget hidden.");
+
+  await handler!("", ctx);
+  assert.equal(visibility.isVisible(), true);
+  assert.deepEqual(transitions, ["show", "hide", "show"]);
+  assert.equal(notices.at(-1), "[pi-emote] Widget shown.");
+});
+
+test("the visibility lifecycle is idempotent and ignores commands without a UI", async () => {
+  const transitions: string[] = [];
+  const visibility = createWidgetVisibility({
+    show: () => transitions.push("show"),
+    hide: () => transitions.push("hide"),
+  });
+
+  visibility.show();
+  visibility.show();
+  visibility.hide();
+  visibility.hide();
+  assert.deepEqual(transitions, ["show", "hide"]);
+
+  let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+  registerVisibilityCommand({
+    registerCommand(_name: string, options: { handler: typeof handler }) {
+      handler = options.handler;
+    },
+  } as unknown as ExtensionAPI, visibility);
+
+  await handler!("", { hasUI: false, ui: { notify() {} } });
+  assert.equal(visibility.isVisible(), false);
+  assert.deepEqual(transitions, ["show", "hide"]);
+});


### PR DESCRIPTION
## Summary

- add `/pi-emote-toggle` to hide or restore the widget for the current session
- stop animation work and dispose terminal image resources while hidden
- cancel delayed blink and think callbacks so they cannot redraw after hiding
- document the command and its session-only behavior

## Tests

- `node --test "tests/*.test.ts"`
- `node --check src/animator.ts`
- `node --check src/index.ts`
- `node --check src/visibility.ts`
- `git diff --check`